### PR TITLE
Fix code scanning alert no. 9: Incomplete string escaping or encoding

### DIFF
--- a/apps/canvas2d/lib/build.js
+++ b/apps/canvas2d/lib/build.js
@@ -1429,7 +1429,7 @@ debug.enable = function(name) {
     , len = split.length;
 
   for (var i = 0; i < len; i++) {
-    name = split[i].replace('*', '.*?');
+    name = split[i].replace(/\*/g, '.*?');
     if (name[0] === '-') {
       debug.skips.push(new RegExp('^' + name.substr(1) + '$'));
     }


### PR DESCRIPTION
Fixes [https://github.com/zlatnaspirala/matrix-engine-starter/security/code-scanning/9](https://github.com/zlatnaspirala/matrix-engine-starter/security/code-scanning/9)

To fix the problem, we need to ensure that all occurrences of the asterisk (`*`) character in the input string are replaced, not just the first one. This can be achieved by using a regular expression with the global flag (`g`). Specifically, we should replace the line `split[i].replace('*', '.*?')` with `split[i].replace(/\*/g, '.*?')`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
